### PR TITLE
Fix styles install path for bearnie add styles

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "window.title": "${activeEditorShort}${separator}${rootName}${separator}${profileName}${separator}[Branch: main]"
+    "window.title": "${activeEditorShort}${separator}${rootName}${separator}${profileName}${separator}[Branch: fix/styles-install-path]"
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -113,6 +113,7 @@ After running `init`, a `bearnie.json` file is created in your project root:
 {
   "componentsDir": "src/components/bearnie",
   "utilsDir": "src/utils",
+  "stylesDir": "src/styles",
   "typescript": true
 }
 ```
@@ -123,6 +124,7 @@ After running `init`, a `bearnie.json` file is created in your project root:
 | --------------- | --------- | --------------------- | -------------------------------------------- |
 | `componentsDir` | `string`  | `"src/components/bearnie"` | Directory where components will be installed |
 | `utilsDir`      | `string`  | `"src/utils"`         | Directory for utility functions              |
+| `stylesDir`     | `string`  | `"src/styles"`        | Directory for theme styles                   |
 | `typescript`    | `boolean` | `true`                | Whether to use TypeScript                    |
 
 ## Environment Variables

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -7,6 +7,7 @@ import { execa } from "execa";
 import {
   getProjectConfig,
   DEFAULT_CONFIG,
+  resolveInstallPath,
 } from "../utils/config.js";
 import {
   getRegistryIndex,
@@ -161,13 +162,12 @@ export async function add(components: string[], options: AddOptions) {
 
       // Write files
       for (const file of component.files) {
-        const isUtilityFile =
-          component.type === "utility" || file.path.startsWith("utils/");
-        const relativePath = isUtilityFile
-          ? file.path.replace(/^utils\//, "")
-          : file.path;
-        const baseDir = isUtilityFile ? config.utilsDir : config.componentsDir;
-        const filePath = path.join(cwd, baseDir, relativePath);
+        const filePath = resolveInstallPath(
+          cwd,
+          config,
+          file.path,
+          component.type
+        );
         const exists = await fs.pathExists(filePath);
 
         if (exists && !options.yes) {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -132,6 +132,7 @@ export async function init(options: InitOptions) {
   try {
     await fs.ensureDir(path.join(cwd, config.componentsDir));
     await fs.ensureDir(path.join(cwd, config.utilsDir));
+    await fs.ensureDir(path.join(cwd, config.stylesDir));
     spinner.text = "Creating directories...";
   } catch (error) {
     spinner.fail("Couldn't create directories");

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -4,6 +4,7 @@ import fs from "fs-extra";
 export interface ProjectConfig {
   componentsDir: string;
   utilsDir: string;
+  stylesDir: string;
   tailwindConfig: string;
   typescript: boolean;
 }
@@ -11,6 +12,7 @@ export interface ProjectConfig {
 export const DEFAULT_CONFIG: ProjectConfig = {
   componentsDir: "src/components/bearnie",
   utilsDir: "src/utils",
+  stylesDir: "src/styles",
   tailwindConfig: "tailwind.config.mjs",
   typescript: true,
 };
@@ -24,7 +26,7 @@ export async function getProjectConfig(
 
   if (await fs.pathExists(configPath)) {
     const content = await fs.readFile(configPath, "utf-8");
-    return JSON.parse(content);
+    return { ...DEFAULT_CONFIG, ...JSON.parse(content) };
   }
 
   return null;
@@ -91,6 +93,28 @@ export async function writeComponentFile(
   await fs.writeFile(fullPath, content);
 
   return { written: true, path: fullPath };
+}
+
+export function resolveInstallPath(
+  cwd: string,
+  config: ProjectConfig,
+  filePath: string,
+  componentType?: string
+): string {
+  const isUtilityFile =
+    componentType === "utility" || filePath.startsWith("utils/");
+  const isStylesFile =
+    componentType === "styles" || filePath.startsWith("styles/");
+
+  if (isUtilityFile) {
+    return path.join(cwd, config.utilsDir, filePath.replace(/^utils\//, ""));
+  }
+
+  if (isStylesFile) {
+    return path.join(cwd, config.stylesDir, filePath.replace(/^styles\//, ""));
+  }
+
+  return path.join(cwd, config.componentsDir, filePath);
 }
 
 export async function writeUtilFile(

--- a/packages/cli/src/utils/registry.ts
+++ b/packages/cli/src/utils/registry.ts
@@ -13,7 +13,7 @@ export const REGISTRY_INDEX_URL = `${REGISTRY_URL}/index.json`;
 
 export interface RegistryComponent {
   name: string;
-  type?: "component" | "utility";
+  type?: "component" | "utility" | "styles";
   description: string;
   category: string;
   dependencies?: string[];

--- a/src/components/global/Footer.astro
+++ b/src/components/global/Footer.astro
@@ -24,9 +24,9 @@ import Wrapper from "@/components/fundations/containers/Wrapper.astro";
         >
       </Text>
       <iframe
-        class="w-fit mx-auto mt-4"
+        class="mx-auto mt-4"
         id="kobbe-embed-live"
-        src="https://app.kobbe.io/embed/embed_f101ae92949ad5fdab463e7bfb2c0325/live?primaryColor=525252&theme=system"
+        src="https://app.kobbe.io/embed/embed_f101ae92949ad5fdab463e7bfb2c0325/live?primaryColor=648ff5&theme=dark"
         width="288"
         height="52"
         style="background:transparent!important;border:none;display:block;width:288px;height:52px;overflow:hidden;"

--- a/src/components/global/Footer.astro
+++ b/src/components/global/Footer.astro
@@ -7,7 +7,11 @@ import Wrapper from "@/components/fundations/containers/Wrapper.astro";
 <footer>
   <Wrapper class="py-8">
     <div class="max-w-2xl mx-auto text-center">
-      <Text tag="p" variant="textSM" class="text-muted-foreground">
+      <Text
+        tag="p"
+        variant="textSM"
+        class="text-muted-foreground flex gap-1 flex-wrap justify-center"
+      >
         Built by
         <a
           target="_blank"
@@ -24,9 +28,9 @@ import Wrapper from "@/components/fundations/containers/Wrapper.astro";
         >
       </Text>
       <iframe
-        class="mx-auto mt-4"
+        class="mx-auto mt-2"
         id="kobbe-embed-live"
-        src="https://app.kobbe.io/embed/embed_f101ae92949ad5fdab463e7bfb2c0325/live?primaryColor=648ff5&theme=dark"
+        src="https://app.kobbe.io/embed/embed_f101ae92949ad5fdab463e7bfb2c0325/live?primaryColor=648ff5&theme=system"
         width="288"
         height="52"
         style="background:transparent!important;border:none;display:block;width:288px;height:52px;overflow:hidden;"

--- a/src/components/global/navigation/Navigation.astro
+++ b/src/components/global/navigation/Navigation.astro
@@ -9,7 +9,7 @@ import ThemeToggle from "@/components/fundations/elements/ThemeToggle.astro";
 import LogoContextMenu from "@/components/global/LogoContextMenu.astro";
 // Icons
 import HugeIcon from "@/components/fundations/icons/HugeIcon.astro";
-import { Github01Icon, Menu01Icon } from "@/lib/hugeicons";
+import { Github01Icon, Hamburger01Icon } from "@/lib/hugeicons";
 import { siteConfig } from "@/config/site";
 export interface Props {
   variant?: "default" | "docs";
@@ -82,10 +82,10 @@ const githubRepoSlug = new URL(githubUrl).pathname.slice(1);
             <button
               type="button"
               class="inline-flex items-center justify-center size-7 text-muted-foreground"
-              id="docs-mobile-Menu01Icon-toggle"
-              aria-label="Toggle Menu01Icon"
+              id="docs-mobile-menu-toggle"
+              aria-label="Toggle menu"
             >
-              <HugeIcon icon={Menu01Icon} size="md" />
+              <HugeIcon icon={Hamburger01Icon} size="md" />
             </button>
           </div>
         </div>

--- a/src/components/global/navigation/TableOfContents.astro
+++ b/src/components/global/navigation/TableOfContents.astro
@@ -18,6 +18,34 @@ const { contentId = "docs-content" } = Astro.props;
 
   <!-- Banner - fixed at bottom -->
   <div class="shrink-0 pt-6">
+    <iframe
+      id="kobbe-embed-live"
+      src="https://app.kobbe.io/embed/embed_f101ae92949ad5fdab463e7bfb2c0325/live?primaryColor=648ff5&theme=light"
+      width="288"
+      height="52"
+      style="background:transparent!important;border:none;display:block;width:100%;max-width:288px;height:52px;overflow:hidden;"
+      frameborder="0"
+      allowtransparency="true"
+      loading="lazy"
+      title="Kobbe live visitors"
+      scrolling="no"></iframe><script>
+      (function () {
+        var o = "https://app.kobbe.io";
+        window.addEventListener("message", function (e) {
+          if (e.origin !== o) return;
+          var d = e.data;
+          if (
+            !d ||
+            d.type !== "kobbe:embed-widget-height" ||
+            d.kind !== "live" ||
+            typeof d.height !== "number"
+          )
+            return;
+          var f = document.getElementById("kobbe-embed-live");
+          if (f) f.style.height = d.height + "px";
+        });
+      })();
+    </script>
     <div class="bg-muted/50 rounded-lg border p-4">
       <h3 class="text-sm font-semibold tracking-tight text-foreground">
         Premium Astro V6 & Tailwind CSS themes

--- a/src/components/landing/Hero.astro
+++ b/src/components/landing/Hero.astro
@@ -5,7 +5,7 @@ import Wrapper from "@/components/fundations/containers/Wrapper.astro";
 ---
 
 <section>
-  <Wrapper variant="standard" class="py-12 lg:py-24">
+  <Wrapper variant="standard" class="py-12 lg:py-20">
     <Text tag="h1" variant="displaySM"> Hero </Text>
     <Text tag="p" variant="textBase"> Hero goes your hero </Text>
   </Wrapper>

--- a/src/lib/hugeicons.ts
+++ b/src/lib/hugeicons.ts
@@ -87,5 +87,6 @@ export { default as Rocket01Icon } from "@hugeicons/core-free-icons/Rocket01Icon
 export { default as Call02Icon } from "@hugeicons/core-free-icons/Call02Icon";
 export { default as Image01Icon } from "@hugeicons/core-free-icons/Image01Icon";
 export { default as Github01Icon } from "@hugeicons/core-free-icons/Github01Icon";
+export { default as Hamburger01Icon } from "@hugeicons/core-free-icons/Hamburger01Icon";
 export { default as Globe02Icon } from "@hugeicons/core-free-icons/Globe02Icon";
 export { default as Menu01Icon } from "@hugeicons/core-free-icons/Menu01Icon";

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -63,7 +63,7 @@ const canonical = `${siteConfig.url}${Astro.url.pathname === "/" ? "" : Astro.ur
   <section>
     <Wrapper
       class="standard"
-      class="py-12 lg:h-[calc(100vh-11.5rem)] flex flex-col justify-center"
+      class="py-12 lg:h-[calc(100vh-15rem)] flex flex-col justify-center"
     >
       <!-- Hero Section -->
       <div class="max-w-sm text-center mx-auto text-balance">
@@ -76,8 +76,8 @@ const canonical = `${siteConfig.url}${Astro.url.pathname === "/" ? "" : Astro.ur
           This is not a component library. <br /> This is your component library
         </Text>
         <Text tag="p" variant="textBase" class="text-muted-foreground mt-4">
-          Accessible components for Astro and Tailwind CSS. Components are
-          added to your project with the CLI. You own and control the code.
+          Accessible components for Astro and Tailwind CSS. Components are added
+          to your project with the CLI. You own and control the code.
         </Text>
 
         <div class="flex items-center gap-2.5 mt-12 justify-center">


### PR DESCRIPTION
## Summary

Running bearnie add styles was putting bearnie.css in src/components/bearnie/styles instead of src/styles. This change routes style files to the correct directory, adds a stylesDir config option, and keeps existing bearnie.json files working by falling back to the default path.

Fixes #3

## Test plan

- [x] Run bearnie add styles and confirm bearnie.css is created at src/styles/bearnie.css
- [x] Run bearnie add button dialog and confirm components still land in src/components/bearnie
- [x] Confirm registry dependencies like focus-trap still land in src/utils

Made with [Cursor](https://cursor.com)